### PR TITLE
CONTRIBUTION update for setup keystore, env variables 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .svn/
 migrate_working_dir/
 .vscode
+temp/
 
 # IntelliJ related
 *.iml
@@ -44,3 +45,7 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# CMake
+android/app/.cxx/
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# 📝 How to contribute
+# 📝 How to Contribute
 
 ### 1. Open an Issue:
 
@@ -22,32 +22,178 @@
 
 ---
 
-# 🛠️ Building from source
+# 🛠️ Building from Source
 
 Learn how to build Mindful from source.
 
-1. Setup the Flutter environment for your [platform](https://docs.flutter.dev/get-started/install)
+## Prerequisites
 
-2. Clone the repository
+1. **Set Up Flutter Environment**:
 
-   ```sh
-   git clone https://github.com/akaMrNagar/Mindful.git && cd mindful
+   - Follow the official Flutter installation guide for your platform: [Flutter Installation Guide](https://docs.flutter.dev/get-started/install).
+
+2. **Update Flutter JDK to Version 17**:
+
+   - Flutter requires JDK 17 for Android development. Set the JDK path using the following command:
+     ```bash
+     flutter config --jdk-dir=<path/to/jdk17>
+     ```
+   - Example for Linux:
+     ```bash
+     flutter config --jdk-dir=/usr/lib/jvm/java-17-openjdk
+     ```
+   - Example for Windows:
+     ```bash
+     flutter config --jdk-dir="C:\Program Files\Java\jdk-17"
+     ```
+
+3. **Clone the Repository**:
+
+   ```bash
+   git clone https://github.com/akaMrNagar/Mindful.git && cd Mindful
    ```
 
-3. Get dependencies
+4. **Get Dependencies**:
 
-   ```sh
+   ```bash
    flutter pub get
    ```
 
-4. Generate temporary files
-
-   ```sh
+5. **Generate Temporary Files**:
+   ```bash
    dart run build_runner build -d
    ```
 
-5. Build the APK
+---
 
-   ```sh
-   flutter build apk
+## Generating a Keystore
+
+To build the app in release mode, you need a keystore. Follow these steps to generate one:
+
+### For Linux/macOS:
+
+1. Create a temporary directory inside the project:
+
+   ```bash
+   mkdir -p temp
    ```
+
+2. Generate the keystore inside the `temp` folder:
+
+   ```bash
+   keytool -genkey -v -keystore temp/mindful.jks -keyalg RSA -keysize 2048 -validity 10000 -alias mindful
+   ```
+
+   - You will be prompted to enter a **keystore password**, **key password**, and other details.
+
+3. Set the keystore file permissions:
+   ```bash
+   chmod 600 temp/mindful.jks
+   ```
+
+### For Windows:
+
+1. Create a temporary folder inside the project:
+
+   ```batch
+   mkdir temp
+   ```
+
+2. Generate the keystore inside the `temp` folder:
+   ```batch
+   keytool -genkey -v -keystore temp\mindful.jks -keyalg RSA -keysize 2048 -validity 10000 -alias mindful
+   ```
+   - You will be prompted to enter a **keystore password**, **key password**, and other details.
+
+---
+
+## Setting Environment Variables
+
+To use the keystore during the build process, set the following environment variables:
+
+### For Linux/macOS:
+
+1. Create a script file in `temp` (e.g., `temp/keystore.sh`):
+
+   ```bash
+   #!/bin/bash
+
+   export KEYSTORE_FILE="$(pwd)/temp/mindful.jks"
+   export STORE_PASSWORD="your_keystore_password"
+   export KEY_ALIAS="mindful"
+   export KEY_PASSWORD="your_key_password"
+
+   echo "KEYSTORE_FILE: $KEYSTORE_FILE"
+   echo "STORE_PASSWORD: $STORE_PASSWORD"
+   echo "KEY_ALIAS: $KEY_ALIAS"
+   echo "KEY_PASSWORD: $KEY_PASSWORD"
+   ```
+
+2. Make the script executable:
+
+   ```bash
+   chmod +x temp/keystore.sh
+   ```
+
+3. Source the script before building the app:
+   ```bash
+   source temp/keystore.sh
+   ```
+
+### For Windows:
+
+1. Create a batch file in `temp` (e.g., `temp/keystore.bat`):
+
+   ```batch
+   @echo off
+   set KEYSTORE_FILE=%CD%\temp\mindful.jks
+   set STORE_PASSWORD=your_keystore_password
+   set KEY_ALIAS=mindful
+   set KEY_PASSWORD=your_key_password
+
+   echo KEYSTORE_FILE: %KEYSTORE_FILE%
+   echo STORE_PASSWORD: %STORE_PASSWORD%
+   echo KEY_ALIAS: %KEY_ALIAS%
+   echo KEY_PASSWORD: %KEY_PASSWORD%
+   ```
+
+2. Run the batch file before building the app:
+   ```batch
+   temp\keystore.bat
+   ```
+
+**Note:** The `temp/` directory is ignored by Git to ensure sensitive files like keystores and environment scripts are not accidentally committed.
+
+## Building the APK
+
+1. Build the APK in release mode:
+
+   ```bash
+   flutter build apk --release
+   ```
+
+2. The APK will be generated at:
+   ```
+   build/app/outputs/flutter-apk/app-release.apk
+   ```
+
+---
+
+## Troubleshooting
+
+- **Missing `storeFile` Error**:
+  Ensure the `KEYSTORE_FILE` environment variable is correctly set and points to a valid keystore file.
+
+- **JDK Version Issues**:
+  Verify that the JDK version is set to 17:
+
+  ```bash
+  flutter doctor -v
+  ```
+
+- **Environment Variables Not Available**:
+  Ensure the environment variables are set in the same terminal where you run the build command.
+
+---
+
+By following these steps, you can successfully set up the project, generate a keystore, and build Mindful from source. Let us know if you encounter any issues! 😊

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -69,18 +69,18 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   build:
     dependency: transitive
     description:
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   charcode:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -277,10 +277,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -505,18 +505,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -585,10 +585,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -601,10 +601,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -625,10 +625,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_parsing:
     dependency: transitive
     description:
@@ -806,10 +806,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.1"
   sqlite3:
     dependency: "direct main"
     description:
@@ -838,10 +838,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   state_notifier:
     dependency: transitive
     description:
@@ -854,10 +854,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   stream_transform:
     dependency: transitive
     description:
@@ -870,26 +870,26 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.4"
   timing:
     dependency: transitive
     description:
@@ -942,10 +942,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.0"
+    version: "14.3.1"
   watcher:
     dependency: transitive
     description:
@@ -1011,5 +1011,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.24.0"


### PR DESCRIPTION
fixes: #80 

1. gitignore:
 - added temp/ and android/app/.cxx/ so that devs can store scripts and other stuff in temp and .cxx for cmake build files generated on linux

2. Contribution.md update to better show case how to setup including creation of key and env setup.

