### PR TITLE
Use debug keystore if keystore envs are not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .svn/
 migrate_working_dir/
 .vscode
+temp/
 
 # IntelliJ related
 *.iml
@@ -44,3 +45,5 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+/android/app/.cxx/
+

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -62,19 +62,30 @@ android {
                 debugSymbolLevel 'full'
             }
             resValue "string", "app_name", "Mindful"
-            signingConfig = signingConfigs.release
+            signingConfig signingConfigs.release
+            
+            // If you see "SigningConfig 'release' is missing required property 'storeFile'",  
+            // it means your release keystore is not set up due to missing environment variables.  
+            // To fix this locally, either:  
+            // 1. Use `signingConfig signingConfigs.debug` (but DO NOT commit this change).  
+            // 2. Set the following environment variables to keep signing secure:  
+            //    - KEYSTORE_FILE  
+            //    - STORE_PASSWORD  
+            //    - KEY_ALIAS  
+            //    - KEY_PASSWORD  
+            // Avoid pushing any local changes to this Gradle file, as it may break CI/CD.  
         }
 
         debug {
             applicationIdSuffix ".debug"
             resValue "string", "app_name", "Mindful Debug"
-            signingConfig = signingConfigs.release ?: signingConfigs.debug
+            signingConfig System.getenv("KEYSTORE_FILE") != null ? signingConfigs.release : signingConfigs.debug
         }
 
         profile {
             applicationIdSuffix ".profile"
             resValue "string", "app_name", "Mindful Profile"
-            signingConfig = signingConfigs.release ?: signingConfigs.debug
+            signingConfig System.getenv("KEYSTORE_FILE") != null ? signingConfigs.release : signingConfigs.debug
         }
     }
     buildFeatures {


### PR DESCRIPTION
Fixes: #80 

Major:
1. Set release config to debug in case relase wasn't found. 
 - I was planning to add debug and release configs separate but when relase keystore is not found it causes exception so. And i could add ternary operator but then i though u use relase key for debug as well so i avoided that and the current implmentation worked best acc. to me.
 - It give log on terminal if debug key was used or release key from env variables let me if any changes are needed.

Minor: 
 - temp/ in gitignore to add scripts and other temp works for devs.
 - ignore cxx build dirs and android generates them in linux