### PR TITLE
Fix : Typo "Summery" → "Summary" 

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -211,7 +211,7 @@
     "batched_apps_tile_title": "Batched apps",
     "batch_recap_dropdown_title": "Batch recap type",
     "batch_recap_dropdown_info": "Choose what to push when a schedule triggers — all notifications or just a summary.",
-    "batch_recap_option_summery_only": "Summery only",
+    "batch_recap_option_summery_only": "Summary only",
     "batch_recap_option_all_notifications": "All notifications",
     "notification_history_tile_title": "Notification history",
     "store_all_tile_title": "Store all notifications",

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -618,7 +618,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Choose what to push when a schedule triggers — all notifications or just a summary.';
 
   @override
-  String get batch_recap_option_summery_only => 'Summery only';
+  String get batch_recap_option_summery_only => 'Summary only';
 
   @override
   String get batch_recap_option_all_notifications => 'All notifications';


### PR DESCRIPTION
Correct the misspelling of "Summery only" to "Summary only" in English localization files. Update both the ARB source (app_en.arb) and the generated Dart localization (app_localizations_en.dart) so the displayed UI text is consistent and the build no longer contains an incorrect string. This prevents user-facing typos in batch recap options.

Closes #204 