### PR TITLE
Add columndeeply/hosts to NSFW blocklist

### DIFF
--- a/android/app/src/main/java/com/mindful/android/utils/NsfwDomains.kt
+++ b/android/app/src/main/java/com/mindful/android/utils/NsfwDomains.kt
@@ -64,59 +64,69 @@ object NsfwDomains {
         addY()
         addZ()
 
-        addColumndeeplyHosts00()
+        addColumndeeplyHosts()
 
         Log.d(TAG, "init: Nsfw domains initialized successfully")
         return dict
     }
 
-    fun addColumndeeplyHosts00(context: Context) {
-        val cacheFile = File(context.cacheDir, "hosts00")
-        val sourceUrl = "https://raw.githubusercontent.com/columndeeply/hosts/main/hosts00"
+    fun addColumndeeplyHosts(context: Context) {
+        val baseUrl = "https://raw.githubusercontent.com/columndeeply/hosts/main/hosts"
+        val cacheDir = context.cacheDir
     
         try {
-            // Download and cache if not already cached (timeout: 15 secs)
-            if (!cacheFile.exists()) {
-                val url = URL(sourceUrl)
-                val connection = url.openConnection() as HttpURLConnection
-                connection.connectTimeout = 15_000
-                connection.readTimeout = 15_000
-                connection.requestMethod = "GET"
+            // Download & add hosts00 up to hosts05
+            for (i in 0..5) {
+                val suffix = String.format("%02d", i)
+                val fileName = "hosts$suffix"
+                val sourceUrl = "$baseUrl$suffix"
+                val cacheFile = File(cacheDir, fileName)
     
-                connection.inputStream.use { input ->
-                    cacheFile.outputStream().use { output ->
-                        input.copyTo(output)
+                // Download and cache if not already cached (timeout: 15 secs)
+                if (!cacheFile.exists()) {
+                    val url = URL(sourceUrl)
+                    val connection = url.openConnection() as HttpURLConnection
+                    connection.connectTimeout = 15_000
+                    connection.readTimeout = 15_000
+                    connection.requestMethod = "GET"
+    
+                    connection.inputStream.use { input ->
+                        cacheFile.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
                     }
+    
+                    connection.disconnect()
+                    Log.d(TAG, "addColumndeeplyHosts: $fileName downloaded and cached")
                 }
     
-                connection.disconnect()
-                Log.d(TAG, "addColumndeeplyHosts00: hosts00 downloaded and cached")
-            }
+                // Read cached file and extract domains
+                cacheFile.bufferedReader().useLines { lines ->
+                    lines.forEach { line ->
+                        val trimmed = line.trim()
+                        if (trimmed.isEmpty()) return@forEach
     
-            // Read cached file and extract domains
-            cacheFile.bufferedReader().useLines { lines ->
-                lines.forEach { line ->
-                    val trimmed = line.trim()
-                    if (trimmed.isEmpty()) return@forEach
-    
-                    // Expected format: "127.0.0.1 domain.tld"
-                    // Instead of substring("127.0.0.1 ".length), split at " " for safety
-                    val spaceIndex = trimmed.indexOf(' ')
-                    if (spaceIndex > 0 && spaceIndex < trimmed.length - 1) {
-                        val domain = trimmed.substring(spaceIndex + 1).trim()
-                        if (domain.isNotEmpty()) { // better safe than sorry
-                            dict[domain] = true
+                        // Expected format: "127.0.0.1 domain.tld"
+                        // Instead of substring("127.0.0.1 ".length), split at " " for safety
+                        val spaceIndex = trimmed.indexOf(' ')
+                        if (spaceIndex > 0 && spaceIndex < trimmed.length - 1) {
+                            val domain = trimmed.substring(spaceIndex + 1).trim()
+                            if (domain.isNotEmpty()) { // better safe than sorry
+                                dict[domain] = true
+                            }
                         }
                     }
                 }
+                
+                Log.d(TAG, "addColumndeeplyHosts: $fileName domains added successfully")
             }
     
-            Log.d(TAG, "addColumndeeplyHosts00: domains added successfully")
     
         } catch (e: Exception) {
-            Log.e(TAG, "addColumndeeplyHosts00: failed", e)
+            Log.e(TAG, "addColumndeeplyHosts: failed", e)
         }
     }
+
 
     fun add0() {
         val domains = arrayOf(

--- a/android/app/src/main/java/com/mindful/android/utils/NsfwDomains.kt
+++ b/android/app/src/main/java/com/mindful/android/utils/NsfwDomains.kt
@@ -74,6 +74,9 @@ object NsfwDomains {
         val baseUrl = "https://raw.githubusercontent.com/columndeeply/hosts/main/hosts"
         val cacheDir = context.cacheDir
     
+        // Cache invalidation: 20 days
+        val cacheValidityMillis = 20L * 24 * 60 * 60 * 1000
+    
         try {
             // Download & add hosts00 up to hosts05
             for (i in 0..5) {
@@ -82,8 +85,12 @@ object NsfwDomains {
                 val sourceUrl = "$baseUrl$suffix"
                 val cacheFile = File(cacheDir, fileName)
     
-                // Download and cache if not already cached (timeout: 15 secs)
-                if (!cacheFile.exists()) {
+                val cacheExpired =
+                    !cacheFile.exists() ||
+                    (System.currentTimeMillis() - cacheFile.lastModified() > cacheValidityMillis)
+    
+                // Download and cache if not already cached or cache expired (timeout: 15 secs)
+                if (cacheExpired) {
                     val url = URL(sourceUrl)
                     val connection = url.openConnection() as HttpURLConnection
                     connection.connectTimeout = 15_000
@@ -117,10 +124,9 @@ object NsfwDomains {
                         }
                     }
                 }
-                
+    
                 Log.d(TAG, "addColumndeeplyHosts: $fileName domains added successfully")
             }
-    
     
         } catch (e: Exception) {
             Log.e(TAG, "addColumndeeplyHosts: failed", e)

--- a/android/app/src/main/java/com/mindful/android/utils/NsfwDomains.kt
+++ b/android/app/src/main/java/com/mindful/android/utils/NsfwDomains.kt
@@ -3,6 +3,7 @@
  *  *
  *  *  * Copyright (c) 2024 Mindful (https://github.com/akaMrNagar/Mindful)
  *  *  * Author : Pawan Nagar (https://github.com/akaMrNagar)
+ *  *  * Extended by : Ludwig Lehnert (https://github.com/lehlud) in 2025
  *  *  *
  *  *  * This source code is licensed under the GPL-2.0 license license found in the
  *  *  * LICENSE file in the root directory of this source tree.
@@ -11,8 +12,13 @@
  */
 package com.mindful.android.utils
 
+import android.content.Context
 import android.util.Log
-
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
 
 // Note: I have found this list of domains somewhere i didn't know.
 // If your are the owner or the curator of this domains list please let us know about it.
@@ -58,8 +64,58 @@ object NsfwDomains {
         addY()
         addZ()
 
+        addColumndeeplyHosts00()
+
         Log.d(TAG, "init: Nsfw domains initialized successfully")
         return dict
+    }
+
+    fun addColumndeeplyHosts00(context: Context) {
+        val cacheFile = File(context.cacheDir, "hosts00")
+        val sourceUrl = "https://raw.githubusercontent.com/columndeeply/hosts/main/hosts00"
+    
+        try {
+            // Download and cache if not already cached (timeout: 15 secs)
+            if (!cacheFile.exists()) {
+                val url = URL(sourceUrl)
+                val connection = url.openConnection() as HttpURLConnection
+                connection.connectTimeout = 15_000
+                connection.readTimeout = 15_000
+                connection.requestMethod = "GET"
+    
+                connection.inputStream.use { input ->
+                    cacheFile.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+    
+                connection.disconnect()
+                Log.d(TAG, "addColumndeeplyHosts00: hosts00 downloaded and cached")
+            }
+    
+            // Read cached file and extract domains
+            cacheFile.bufferedReader().useLines { lines ->
+                lines.forEach { line ->
+                    val trimmed = line.trim()
+                    if (trimmed.isEmpty()) return@forEach
+    
+                    // Expected format: "127.0.0.1 domain.tld"
+                    // Instead of substring("127.0.0.1 ".length), split at " " for safety
+                    val spaceIndex = trimmed.indexOf(' ')
+                    if (spaceIndex > 0 && spaceIndex < trimmed.length - 1) {
+                        val domain = trimmed.substring(spaceIndex + 1).trim()
+                        if (domain.isNotEmpty()) { // better safe than sorry
+                            dict[domain] = true
+                        }
+                    }
+                }
+            }
+    
+            Log.d(TAG, "addColumndeeplyHosts00: domains added successfully")
+    
+        } catch (e: Exception) {
+            Log.e(TAG, "addColumndeeplyHosts00: failed", e)
+        }
     }
 
     fun add0() {


### PR DESCRIPTION
This PR introduces `addColumndeeplyHosts`, which downloads and integrates the hosts00–hosts05 lists from the [columndeeply/hosts](https://github.com/columndeeply/hosts) repository. The implementation caches each hosts file locally, applies a 20-day cache invalidation policy to keep data reasonably fresh (columndeeply/hosts is updated every 30 days), and safely parses domains from each list into the NSFW domain map.